### PR TITLE
Fix for Android App Crash Due to Uninitialized Courier SDK

### DIFF
--- a/android/src/main/java/com/courierreactnative/CourierReactNativeActivity.kt
+++ b/android/src/main/java/com/courierreactnative/CourierReactNativeActivity.kt
@@ -13,11 +13,11 @@ import org.json.JSONObject
 open class CourierReactNativeActivity : ReactActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-
     // Starts the Courier SDK
     // Used to ensure shared preferences works properly
     Courier.initialize(this)
+
+    super.onCreate(savedInstanceState)
 
     // See if there is a pending click event
     checkIntentForPushNotificationClick(intent)


### PR DESCRIPTION
Hi team,

we've recently encountered app crash from time to time with our Android application. The crash logs:
```
Fatal Exception: java.lang.RuntimeException
com.courier.android.models.CourierException: Courier SDK not initialized. Run Courier.initialize(context) to fix this
    com.courier.android.Courier$Companion.getShared (Courier.kt:66)
    com.courierreactnative.CourierReactNativeModule.<init> (CourierReactNativeModule.kt:36)
    com.courierreactnative.CourierReactNativePackage.createNativeModules (CourierReactNativePackage.kt:11)
    com.facebook.react.ReactPackageHelper.getNativeModuleIterator (ReactPackageHelper.java:42)
    com.facebook.react.NativeModuleRegistryBuilder.processPackage (NativeModuleRegistryBuilder.java:42)
    com.facebook.react.ReactInstanceManager.processPackage (ReactInstanceManager.java:1467)
    com.facebook.react.ReactInstanceManager.processPackages (ReactInstanceManager.java:1438)
    com.facebook.react.ReactInstanceManager.createReactContext (ReactInstanceManager.java:1340)
    com.facebook.react.ReactInstanceManager.-$$Nest$mcreateReactContext
    com.facebook.react.ReactInstanceManager$5.run (ReactInstanceManager.java:1111)
    java.lang.Thread.run (Thread.java:1012)
```

In my thought, The root cause of this crash is the premature [creation of a NativeModule instance](https://github.com/trycourier/courier-react-native/blob/master/android/src/main/java/com/courierreactnative/CourierReactNativeModule.kt#L36-L38) before the Courier SDK is properly initialized. Specifically, the instance variable `mInstance` within the Courier SDK not assigned because `Courier.initialize` has yet to be called.

This situation occur when `ReactActivity.onCreate` is invoked eariler and [ReactContextThread]((https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L1093-L1152)) is early started. This thread responsible for creating NativeModules and etc and can run faster than the main thread.
As a result, when this condition occurs, `Courier.shared` may not exist at the time of the `NativeModule` constructor call and causing the crash above.

So I propose relocating `Courier.initialize` call to the top in the onCreate callback. this adjustment guarantee the initialized Courier instance across all subsequent operations.

Thank you for your attention to this matter and your ongoing support.

@mikemilla @FahadAminShovon Please check :)