### PR TITLE
Add AUTO-GENERATED-OVERVIEW markers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img width="1040" alt="banner-react-native" src="https://github.com/user-attachments/assets/c38f52d8-792f-4b51-a423-f1c5dd9f996b">
 
+<!-- AUTO-GENERATED-OVERVIEW:START — Do not edit this section. It is synced from mintlify-docs. -->
+
 &emsp;
 
 # Requirements & Support
@@ -139,6 +141,8 @@ class MainActivity : CourierReactNativeActivity() {
     ..
 }
 ```
+
+<!-- AUTO-GENERATED-OVERVIEW:END -->
 
 &emsp;
 


### PR DESCRIPTION
## Summary

- Adds `<!-- AUTO-GENERATED-OVERVIEW:START -->` and `<!-- AUTO-GENERATED-OVERVIEW:END -->` markers around the overview/installation section of the README
- Enables the mintlify-docs readme-sync GitHub Action to keep this section in sync with the Courier docs site
- No visible content changes; manual sections (Getting Started, Example Projects, etc.) remain untouched