### PR TITLE
Add deprecation notices to Docs/ and update README links

### DIFF
--- a/Docs/1_Authentication.md
+++ b/Docs/1_Authentication.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/react-native](https://www.courier.com/docs/sdk-libraries/react-native/). The content below may be outdated.
+
 # Authentication
 
 Manages user credentials between app sessions.

--- a/Docs/2_Inbox.md
+++ b/Docs/2_Inbox.md
@@ -1,5 +1,7 @@
 <img width="1040" alt="banner-react-native-inbox" src="https://github.com/trycourier/courier-react-native/assets/6370613/f138f4a4-fa64-417b-91c7-90aa8802624d">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/react-native](https://www.courier.com/docs/sdk-libraries/react-native/). The content below may be outdated.
+
 &emsp;
 
 # Courier Inbox

--- a/Docs/3_PushNotifications.md
+++ b/Docs/3_PushNotifications.md
@@ -1,5 +1,7 @@
 <img width="1040" alt="banner-react-native-push" src="https://github.com/trycourier/courier-react-native/assets/6370613/67762338-2f2b-4b46-bf28-1462ca742fed">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/react-native](https://www.courier.com/docs/sdk-libraries/react-native/). The content below may be outdated.
+
 &emsp;
 
 # Push Notifications

--- a/Docs/4_Preferences.md
+++ b/Docs/4_Preferences.md
@@ -1,5 +1,7 @@
 <img width="1040" alt="banner-react-native-preferences" src="https://github.com/trycourier/courier-react-native/assets/6370613/2d5190c1-5f44-45db-aa26-50e4275ea7f1">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/react-native](https://www.courier.com/docs/sdk-libraries/react-native/). The content below may be outdated.
+
 # Courier Preferences
 
 In-app notification settings that allow your users to customize which of your notifications they receive. Allows you to build high quality, flexible preference settings very quickly.

--- a/Docs/5_Client.md
+++ b/Docs/5_Client.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/react-native](https://www.courier.com/docs/sdk-libraries/react-native/). The content below may be outdated.
+
 # `CourierClient`
 
 Base layer Courier API wrapper.

--- a/Docs/6_Expo.md
+++ b/Docs/6_Expo.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/react-native](https://www.courier.com/docs/sdk-libraries/react-native/). The content below may be outdated.
+
 # Expo
 
 This is how to using `CourierReactNative` in an Expo app.

--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ These are all the available features of the SDK.
                 1
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-react-native/blob/master/Docs/1_Authentication.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/react-native/#authentication">
                     <code>Authentication</code>
                 </a>
             </td>
             <td align="left">
-                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-react-native/blob/master/Docs/2_Inbox.md"><code>Courier Inbox</code></a> and <a href="https://github.com/trycourier/courier-react-native/blob/master/Docs/3_PushNotifications.md"><code>Push Notifications</code></a>.
+                Manages user credentials between app sessions. Required if you would like to use <a href="https://www.courier.com/docs/sdk-libraries/react-native/#inbox"><code>Courier Inbox</code></a> and <a href="https://www.courier.com/docs/sdk-libraries/react-native/#push-notifications"><code>Push Notifications</code></a>.
             </td>
         </tr>
         <tr width="600px">
@@ -173,7 +173,7 @@ These are all the available features of the SDK.
                 2
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-react-native/blob/master/Docs/2_Inbox.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/react-native/#inbox">
                     <code>Inbox</code>
                 </a>
             </td>
@@ -186,7 +186,7 @@ These are all the available features of the SDK.
                 3
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-react-native/blob/master/Docs/3_PushNotifications.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/react-native/#push-notifications">
                     <code>Push Notifications</code>
                 </a>
             </td>
@@ -199,7 +199,7 @@ These are all the available features of the SDK.
                 4
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-react-native/blob/master/Docs/4_Preferences.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/react-native/#preferences">
                     <code>Preferences</code>
                 </a>
             </td>
@@ -212,7 +212,7 @@ These are all the available features of the SDK.
                 5
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-react-native/blob/master/Docs/5_Client.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/react-native/#courierclient">
                     <code>CourierClient</code>
                 </a>
             </td>
@@ -227,7 +227,7 @@ These are all the available features of the SDK.
 
 # Expo
 
-If you are using Expo, you should check out the [Expo Docs](https://github.com/trycourier/courier-react-native/blob/master/Docs/6_Expo.md) for all the details.
+If you are using Expo, you should check out the [Expo Docs](https://www.courier.com/docs/sdk-libraries/react-native/#expo) for all the details.
 
 &emsp;
 


### PR DESCRIPTION
## Summary

- Adds deprecation notices to all 6 files in `Docs/` pointing to the canonical Mintlify docs at courier.com/docs/sdk-libraries/react-native/
- Updates the README "Getting Started" feature table and Expo section to link to Mintlify instead of the GitHub Docs/ files