### PR TITLE
feat: add backgroundColor property to CourierInboxTheme

### DIFF
--- a/Docs/2_Inbox.md
+++ b/Docs/2_Inbox.md
@@ -140,6 +140,7 @@ const defaultFont = Platform.OS === 'ios' ? 'Avenir Medium' : 'fonts/poppins_reg
 
 const lightTheme: CourierInboxTheme = {
   brandId: "your_brand_id",
+  backgroundColor: '#FFFFFF',
   tabIndicatorColor: primaryColor,
   tabStyle: {
     selected: {

--- a/android/src/main/java/com/courierreactnative/CourierInboxViewManager.kt
+++ b/android/src/main/java/com/courierreactnative/CourierInboxViewManager.kt
@@ -119,6 +119,7 @@ class CourierInboxViewManager : SimpleViewManager<CourierInbox>() {
     val dividerItemDecoration = android?.getString("dividerItemDecoration")
 
     val brandId = getString("brandId")
+    val backgroundColor = getString("backgroundColor")
 
     val tabIndicatorColor = getString("tabIndicatorColor")
     val tabStyle = getMap("tabStyle")
@@ -139,6 +140,7 @@ class CourierInboxViewManager : SimpleViewManager<CourierInbox>() {
 
     return CourierInboxTheme(
       brandId = brandId,
+      backgroundColor = backgroundColor?.toColor(),
       tabIndicatorColor = tabIndicatorColor?.toColor(),
       tabStyle = tabStyle?.toTabStyle(context) ?: CourierStyles.Inbox.TabStyle(
         selected = CourierStyles.Inbox.TabItemStyle(

--- a/ios/CourierInboxReactNativeManager.swift
+++ b/ios/CourierInboxReactNativeManager.swift
@@ -314,6 +314,7 @@ internal extension NSDictionary {
         let defaultTheme = CourierInboxTheme()
         
         let brandId = self["brandId"] as? String
+        let backgroundColor = self["backgroundColor"] as? String
         let tabIndicatorColor = self["tabIndicatorColor"] as? String
         let tabStyle = self["tabStyle"] as? NSDictionary
         let readingSwipeActionStyle = self["readingSwipeActionStyle"] as? NSDictionary
@@ -332,6 +333,7 @@ internal extension NSDictionary {
         
         return CourierInboxTheme(
             brandId: brandId,
+            backgroundColor: backgroundColor?.toColor(),
             tabIndicatorColor: tabIndicatorColor?.toColor(),
             tabStyle: tabStyle?.toTabStyle() ?? CourierInboxView.defaultTabStyle(),
             readingSwipeActionStyle: readingSwipeActionStyle?.toReadingSwipeActionStyle() ?? CourierInboxView.defaultReadingStyle(),

--- a/src/models/CourierInboxTheme.tsx
+++ b/src/models/CourierInboxTheme.tsx
@@ -48,6 +48,7 @@ export interface CourierArchivingSwipeActionStyle {
 
 export interface CourierInboxTheme {
   brandId?: string;
+  backgroundColor?: string;
   tabIndicatorColor?: string;
   tabStyle?: CourierInboxTabStyle;
   readingSwipeActionStyle?: CourierReadingSwipeActionStyle;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new optional `backgroundColor` property to `CourierInboxTheme` that allows users to customize the background color of the entire inbox view on both iOS and Android.

Resolves #32

## Problem

Users cannot set the background color of the inbox. The issue reporter tried various approaches including `components.messageList.container.backgroundColor` but nothing works because the theme has no `backgroundColor` field.

## Solution

Added `backgroundColor?: string` to the `CourierInboxTheme` TypeScript interface and bridged it to both native platforms:

- **TypeScript** (`src/models/CourierInboxTheme.tsx`): Added `backgroundColor?: string` to the `CourierInboxTheme` interface
- **iOS bridge** (`ios/CourierInboxReactNativeManager.swift`): Maps the `backgroundColor` string from the RN theme dictionary to the native `CourierInboxTheme` constructor
- **Android bridge** (`android/src/main/java/com/courierreactnative/CourierInboxViewManager.kt`): Maps the `backgroundColor` string from the RN theme ReadableMap to the native `CourierInboxTheme` constructor
- **Docs** (`Docs/2_Inbox.md`): Updated the styled inbox example to show the new property

### Usage

```typescript
const theme: CourierInboxTheme = {
  backgroundColor: '#0C111D',
  // ...other properties
};

<CourierInboxView
  theme={{ light: theme, dark: theme }}
/>
```

## Dependencies

This PR requires corresponding changes in the native SDKs to add the `backgroundColor` property to `CourierInboxTheme`:

- **courier-ios**: Add `backgroundColor: UIColor?` to `CourierInboxTheme` and apply it to the inbox's stack view, scroll view, table view, and tab bar. Changes are prepared in branch `cursor/add-inbox-background-color-d185` (pending push access).
- **courier-android**: Add `@ColorInt backgroundColor: Int?` to `CourierInboxTheme` and apply it to the root layout, tab layout, recycler view, and swipe refresh layout. Changes are prepared in branch `cursor/add-inbox-background-color-d185` (pending push access).

The native SDK versions referenced by this package (`Courier_iOS 5.8.0` and `courier-android 5.3.0`) will need to be updated to versions that include the `backgroundColor` property.

## Files Changed

| File | Change |
|------|--------|
| `src/models/CourierInboxTheme.tsx` | Added `backgroundColor?: string` to interface |
| `ios/CourierInboxReactNativeManager.swift` | Bridge `backgroundColor` to native iOS theme |
| `android/src/main/java/com/courierreactnative/CourierInboxViewManager.kt` | Bridge `backgroundColor` to native Android theme |
| `Docs/2_Inbox.md` | Updated styled example with `backgroundColor` |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd1919f9-ecfc-4bf0-9353-dda13392d185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd1919f9-ecfc-4bf0-9353-dda13392d185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

