### PR TITLE
Merge dependency bumps and add theme backgroundColor support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,7 +110,7 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.11.0'
 
   // Courier Core SDK
-  api 'com.github.trycourier:courier-android:5.3.0'
+  api 'com.github.trycourier:courier-android:5.3.1'
   api 'androidx.recyclerview:recyclerview:1.3.2'
 
 }

--- a/android/src/main/java/com/courierreactnative/CourierInboxViewManager.kt
+++ b/android/src/main/java/com/courierreactnative/CourierInboxViewManager.kt
@@ -119,6 +119,7 @@ class CourierInboxViewManager : SimpleViewManager<CourierInbox>() {
     val dividerItemDecoration = android?.getString("dividerItemDecoration")
 
     val brandId = getString("brandId")
+    val backgroundColor = getString("backgroundColor")
 
     val tabIndicatorColor = getString("tabIndicatorColor")
     val tabStyle = getMap("tabStyle")
@@ -139,6 +140,7 @@ class CourierInboxViewManager : SimpleViewManager<CourierInbox>() {
 
     return CourierInboxTheme(
       brandId = brandId,
+      backgroundColor = backgroundColor?.toColor(),
       tabIndicatorColor = tabIndicatorColor?.toColor(),
       tabStyle = tabStyle?.toTabStyle(context) ?: CourierStyles.Inbox.TabStyle(
         selected = CourierStyles.Inbox.TabItemStyle(

--- a/android/src/main/java/com/courierreactnative/CourierPreferencesViewManager.kt
+++ b/android/src/main/java/com/courierreactnative/CourierPreferencesViewManager.kt
@@ -102,6 +102,7 @@ class CourierPreferencesViewManager : SimpleViewManager<CourierPreferences>() {
   private fun ReadableMap.toTheme(view: CourierPreferences): CourierPreferencesTheme {
 
     val brandId = getString("brandId")
+    val backgroundColor = getString("backgroundColor")
     val loadingIndicatorColor = getString("loadingIndicatorColor")
     val sectionTitleFont = getMap("sectionTitleFont")
     val topicTitleFont = getMap("topicTitleFont")
@@ -118,6 +119,7 @@ class CourierPreferencesViewManager : SimpleViewManager<CourierPreferences>() {
 
     return CourierPreferencesTheme(
       brandId = brandId,
+      backgroundColor = backgroundColor?.toColor(),
       loadingIndicatorColor = loadingIndicatorColor?.toColor(),
       sectionTitleFont = sectionTitleFont?.toFont(context) ?: defaultTheme.sectionTitleFont,
       topicDividerItemDecoration = topicDividerItemDecoration?.toDivider(context),

--- a/android/src/main/java/com/courierreactnative/Utils.kt
+++ b/android/src/main/java/com/courierreactnative/Utils.kt
@@ -15,7 +15,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.google.gson.GsonBuilder
 
 internal object Utils {
-  val COURIER_AGENT = CourierAgent.ReactNativeAndroid(version = "5.7.0")
+  val COURIER_AGENT = CourierAgent.ReactNativeAndroid(version = "5.7.1")
 }
 
 internal fun ReactContext.sendEvent(eventName: String, value: Any?) {

--- a/courier-react-native.podspec
+++ b/courier-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   # Courier Core Dependency
-  s.dependency "Courier_iOS", "5.8.0"
+  s.dependency "Courier_iOS", "5.8.1"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/example/src/AuthPreferences.ts
+++ b/example/src/AuthPreferences.ts
@@ -25,7 +25,7 @@ export interface AuthPreferencesData {
 }
 
 export async function loadAuthPreferences(): Promise<AuthPreferencesData> {
-  const results = await AsyncStorage.getMany([
+  const pairs = await AsyncStorage.multiGet([
     KEYS.environment,
     KEYS.userId,
     KEYS.tenantId,
@@ -35,6 +35,11 @@ export async function loadAuthPreferences(): Promise<AuthPreferencesData> {
     KEYS.inboxGraphqlUrl,
     KEYS.inboxWebSocketUrl,
   ]);
+
+  const results: Record<string, string | null> = {};
+  for (const [key, value] of pairs) {
+    results[key] = value;
+  }
 
   return {
     environment:
@@ -54,19 +59,20 @@ export async function loadAuthPreferences(): Promise<AuthPreferencesData> {
 export async function saveAuthPreferences(
   data: Partial<AuthPreferencesData>
 ): Promise<void> {
-  const entries: Record<string, string> = {};
+  const pairs: [string, string][] = [];
   if (data.environment !== undefined)
-    entries[KEYS.environment] = data.environment;
-  if (data.userId !== undefined) entries[KEYS.userId] = data.userId;
-  if (data.tenantId !== undefined) entries[KEYS.tenantId] = data.tenantId;
-  if (data.apiKey !== undefined) entries[KEYS.apiKey] = data.apiKey;
-  if (data.restUrl !== undefined) entries[KEYS.restUrl] = data.restUrl;
-  if (data.graphqlUrl !== undefined) entries[KEYS.graphqlUrl] = data.graphqlUrl;
+    pairs.push([KEYS.environment, data.environment]);
+  if (data.userId !== undefined) pairs.push([KEYS.userId, data.userId]);
+  if (data.tenantId !== undefined) pairs.push([KEYS.tenantId, data.tenantId]);
+  if (data.apiKey !== undefined) pairs.push([KEYS.apiKey, data.apiKey]);
+  if (data.restUrl !== undefined) pairs.push([KEYS.restUrl, data.restUrl]);
+  if (data.graphqlUrl !== undefined)
+    pairs.push([KEYS.graphqlUrl, data.graphqlUrl]);
   if (data.inboxGraphqlUrl !== undefined)
-    entries[KEYS.inboxGraphqlUrl] = data.inboxGraphqlUrl;
+    pairs.push([KEYS.inboxGraphqlUrl, data.inboxGraphqlUrl]);
   if (data.inboxWebSocketUrl !== undefined)
-    entries[KEYS.inboxWebSocketUrl] = data.inboxWebSocketUrl;
-  if (Object.keys(entries).length > 0) {
-    await AsyncStorage.setMany(entries);
+    pairs.push([KEYS.inboxWebSocketUrl, data.inboxWebSocketUrl]);
+  if (pairs.length > 0) {
+    await AsyncStorage.multiSet(pairs);
   }
 }

--- a/example/src/pages/Styles.tsx
+++ b/example/src/pages/Styles.tsx
@@ -11,6 +11,7 @@ export const Styles = (isDark: boolean) => {
         Platform.OS === 'ios' ? 'Avenir Medium' : 'fonts/poppins_regular.otf',
     },
     Colors: {
+      background: isDark ? '#1C1C1E' : '#FFFFFF',
       heading: isDark ? '#9747FF' : '#9747FF',
       title: isDark ? '#FFFFFF' : '#000000',
       subtitle: isDark ? '#9A9A9A' : '#BEBEBE',

--- a/example/src/pages/inbox/InboxStyled.tsx
+++ b/example/src/pages/inbox/InboxStyled.tsx
@@ -20,6 +20,7 @@ const InboxStyled = () => {
 
     return {
       brandId: Env.brandId,
+      backgroundColor: styles.Colors.background,
       tabIndicatorColor: styles.Colors.action,
       tabStyle: {
         selected: {

--- a/example/src/pages/preferences/PreferencesStyled.tsx
+++ b/example/src/pages/preferences/PreferencesStyled.tsx
@@ -13,6 +13,7 @@ const PreferencesStyled = () => {
 
     return {
       brandId: Env.brandId,
+      backgroundColor: styles.Colors.background,
       sectionTitleFont: {
         family: styles.Fonts.heading,
         size: styles.TextSizes.heading,

--- a/ios/CourierInboxReactNativeManager.swift
+++ b/ios/CourierInboxReactNativeManager.swift
@@ -46,6 +46,14 @@ class CourierInboxView : UIView {
         let lightTheme = theme?["light"] as? NSDictionary
         let darkTheme = theme?["dark"] as? NSDictionary
         
+        let lightBgColor = (lightTheme?["backgroundColor"] as? String)?.toColor()
+        let darkBgColor = (darkTheme?["backgroundColor"] as? String)?.toColor()
+        if let bgColor = traitCollection.userInterfaceStyle == .dark ? darkBgColor ?? lightBgColor : lightBgColor ?? darkBgColor {
+            self.backgroundColor = bgColor
+        } else {
+            self.backgroundColor = nil
+        }
+        
         let courierInbox = CourierInbox(
             canSwipePages: self.canSwipePages,
             lightTheme: lightTheme?.toInboxTheme() ?? .defaultLight,

--- a/ios/CourierPreferencesReactNativeManager.swift
+++ b/ios/CourierPreferencesReactNativeManager.swift
@@ -44,6 +44,14 @@ class CourierPreferencesView : UIView {
         let lightTheme = theme?["light"] as? NSDictionary
         let darkTheme = theme?["dark"] as? NSDictionary
         
+        let lightBgColor = (lightTheme?["backgroundColor"] as? String)?.toColor()
+        let darkBgColor = (darkTheme?["backgroundColor"] as? String)?.toColor()
+        if let bgColor = traitCollection.userInterfaceStyle == .dark ? darkBgColor ?? lightBgColor : lightBgColor ?? darkBgColor {
+            self.backgroundColor = bgColor
+        } else {
+            self.backgroundColor = nil
+        }
+        
         let courierPreferences = CourierPreferences(
             mode: mode?.toMode() ?? .channels(CourierUserPreferencesChannel.allCases),
             lightTheme: lightTheme?.toPreferencesTheme() ?? .defaultLight,

--- a/ios/CourierReactNativeDelegate.m
+++ b/ios/CourierReactNativeDelegate.m
@@ -33,7 +33,7 @@ static NSString *const CourierForegroundOptionsDidChangeNotification = @"iosFore
     if (self) {
       
         // Set the user agent
-        Courier.agent = [CourierAgent reactNativeIOS:@"5.7.0"];
+        Courier.agent = [CourierAgent reactNativeIOS:@"5.7.1"];
         
         // Register for remote notifications
         UIApplication *app = [UIApplication sharedApplication];

--- a/ios/CourierReactNativeEventEmitter.swift
+++ b/ios/CourierReactNativeEventEmitter.swift
@@ -14,7 +14,7 @@ internal class CourierReactNativeEventEmitter: RCTEventEmitter {
         
         // Set the user agent
         // Used to know the platform performing requests
-        Courier.agent = CourierAgent.reactNativeIOS("5.7.0")
+        Courier.agent = CourierAgent.reactNativeIOS("5.7.1")
         
     }
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trycourier/courier-react-native",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trycourier/courier-react-native",
-      "version": "5.7.0",
+      "version": "5.7.1",
       "license": "MIT",
       "dependencies": {
         "react-native-toast-message": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-react-native",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Inbox, Push Notifications, and Preferences for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/models/CourierInboxTheme.tsx
+++ b/src/models/CourierInboxTheme.tsx
@@ -48,6 +48,7 @@ export interface CourierArchivingSwipeActionStyle {
 
 export interface CourierInboxTheme {
   brandId?: string;
+  backgroundColor?: string;
   tabIndicatorColor?: string;
   tabStyle?: CourierInboxTabStyle;
   readingSwipeActionStyle?: CourierReadingSwipeActionStyle;

--- a/src/models/CourierPreferencesTheme.tsx
+++ b/src/models/CourierPreferencesTheme.tsx
@@ -18,6 +18,7 @@ export type CourierPreferencesMode =
 
 export interface CourierPreferencesTheme {
   brandId?: string;
+  backgroundColor?: string;
   loadingIndicatorColor?: string;
   sectionTitleFont?: CourierFont;
   topicTitleFont?: CourierFont;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR merges two dependency bump PRs and adds support for setting a background color in the inbox and preferences themes.

### Merged PRs
- #45 — Bump Courier_iOS to 5.8.1
- #46 — Bump courier-android to 5.3.1

### New Feature: Theme Background Color

Adds a `backgroundColor` property to both `CourierInboxTheme` and `CourierPreferencesTheme`, allowing users to set a custom background color for these views through the theme system.

#### TypeScript
```typescript
const theme: CourierInboxTheme = {
  backgroundColor: '#FFFFFF',
  // ...other theme properties
};
```

#### Implementation Details
- **Android**: Passes `backgroundColor` directly to the native `CourierInboxTheme` and `CourierPreferencesTheme` constructors (supported in courier-android 5.3.1)
- **iOS**: Applies the background color directly on the native UIView since the Courier_iOS SDK theme constructors don't include this property. Respects the current light/dark user interface style.

### Changes
- `src/models/CourierInboxTheme.tsx` — Added `backgroundColor?: string`
- `src/models/CourierPreferencesTheme.tsx` — Added `backgroundColor?: string`
- `ios/CourierInboxReactNativeManager.swift` — Apply background color on the view
- `ios/CourierPreferencesReactNativeManager.swift` — Apply background color on the view
- `android/.../CourierInboxViewManager.kt` — Pass backgroundColor to theme constructor
- `android/.../CourierPreferencesViewManager.kt` — Pass backgroundColor to theme constructor
- `example/` — Updated styled examples to demonstrate backgroundColor usage
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c77f7ba-5dab-4fe2-9796-cc5a4569b765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c77f7ba-5dab-4fe2-9796-cc5a4569b765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

