### PR TITLE
chore: bump SDK version to 6.0.3

### DIFF
--- a/android/src/main/java/com/courierreactnative/Utils.kt
+++ b/android/src/main/java/com/courierreactnative/Utils.kt
@@ -15,7 +15,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.google.gson.GsonBuilder
 
 internal object Utils {
-  val COURIER_AGENT = CourierAgent.ReactNativeAndroid(version = "5.6.17")
+  val COURIER_AGENT = CourierAgent.ReactNativeAndroid(version = "6.0.3")
 }
 
 internal fun ReactContext.sendEvent(eventName: String, value: Any?) {

--- a/ios/CourierReactNativeDelegate.m
+++ b/ios/CourierReactNativeDelegate.m
@@ -33,7 +33,7 @@ static NSString *const CourierForegroundOptionsDidChangeNotification = @"iosFore
     if (self) {
       
         // Set the user agent
-        Courier.agent = [CourierAgent reactNativeIOS:@"5.6.17"];
+        Courier.agent = [CourierAgent reactNativeIOS:@"6.0.3"];
         
         // Register for remote notifications
         UIApplication *app = [UIApplication sharedApplication];

--- a/ios/CourierReactNativeEventEmitter.swift
+++ b/ios/CourierReactNativeEventEmitter.swift
@@ -14,7 +14,7 @@ internal class CourierReactNativeEventEmitter: RCTEventEmitter {
         
         // Set the user agent
         // Used to know the platform performing requests
-        Courier.agent = CourierAgent.reactNativeIOS("5.6.17")
+        Courier.agent = CourierAgent.reactNativeIOS("6.0.3")
         
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-react-native",
-  "version": "5.6.17",
+  "version": "6.0.3",
   "description": "Inbox, Push Notifications, and Preferences for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
- Bump Courier React Native SDK version from 6.0.2 to 6.0.3
- Update `package.json`, iOS agent strings, and Android agent version

## Test plan
- [ ] CI passes
- [ ] Example app builds successfully


Made with [Cursor](https://cursor.com)