### PR TITLE
chore: update homepage to courier.com and bump to 6.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-react-native",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Inbox, Push Notifications, and Preferences for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -54,7 +54,7 @@
   "bugs": {
     "url": "https://github.com/trycourier/courier-react-native/issues"
   },
-  "homepage": "https://github.com/trycourier/courier-react-native#readme",
+  "homepage": "https://courier.com",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
## Summary
- Updates the `homepage` field in `package.json` from the GitHub repo URL to `https://courier.com` so it displays correctly on npm
- Bumps package version from 6.0.3 → 6.0.4

## Test plan
- [ ] Verify `homepage` field shows correctly on npm after publish

Made with [Cursor](https://cursor.com)